### PR TITLE
Disambiguate transitive dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -401,7 +401,7 @@
         <dependency>
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
-          <version>1.2</version>
+          <version>1.0.4</version>
         </dependency>
         <dependency>
           <groupId>com.fasterxml.jackson.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -366,9 +366,85 @@
                     </execution>
                 </executions>
             </plugin>
-
+	    <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-enforcer-plugin</artifactId>
+              <version>3.0.0-M2</version>
+              <configuration>
+                <rules><dependencyConvergence/></rules>
+              </configuration>
+            </plugin>
         </plugins>
     </build>
+    <dependencyManagement>
+      <dependencies>
+        <dependency>
+          <groupId>org.web3j</groupId>
+          <artifactId>utils</artifactId>
+          <version>4.1.1</version>
+        </dependency>
+        <dependency>
+          <groupId>org.web3j</groupId>
+          <artifactId>core</artifactId>
+          <version>4.1.1</version>
+        </dependency>
+        <dependency>
+          <groupId>org.web3j</groupId>
+          <artifactId>parity</artifactId>
+          <version>4.1.1</version>
+        </dependency>
+        <dependency>
+          <groupId>commons-codec</groupId>
+          <artifactId>commons-codec</artifactId>
+          <version>1.11</version>
+        </dependency>
+        <dependency>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+          <version>1.2</version>
+        </dependency>
+        <dependency>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-core</artifactId>
+          <version>2.9.8</version>
+        </dependency>
+        <dependency>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-annotations</artifactId>
+          <version>2.9.8</version>
+        </dependency>
+        <dependency>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-databind</artifactId>
+          <version>2.9.8</version>
+        </dependency>
+        <dependency>
+          <groupId>net.i2p.crypto</groupId>
+          <artifactId>eddsa</artifactId>
+          <version>0.3.0</version>
+        </dependency>
+        <dependency>
+          <groupId>com.github.jnr</groupId>
+          <artifactId>jnr-constants</artifactId>
+          <version>0.9.11</version>
+        </dependency>
+        <dependency>
+          <groupId>com.github.jnr</groupId>
+          <artifactId>jffi</artifactId>
+          <version>1.2.16</version>
+        </dependency>
+        <dependency>
+          <groupId>com.github.jnr</groupId>
+          <artifactId>jnr-ffi</artifactId>
+          <version>2.1.9</version>
+        </dependency>
+        <dependency>
+          <groupId>com.google.api-client</groupId>
+          <artifactId>google-api-client</artifactId>
+          <version>1.26.0</version>
+        </dependency>
+      </dependencies>
+    </dependencyManagement>
     <dependencies>
         <!-- Web3j -->
         <dependency>


### PR DESCRIPTION
## Description

Adds the enforcer plugin to track transitive dependency ambiguities.
Adds explicit dependency resolution heuristics.

## Is this PR related with an open issue?

No.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation

## Documentation

This is the workflow to find and remove transitive dependency ambiguities:

1. Run the enforcer:
`mvn enforcer:enforce -B > ambiguities.txt`
2. Are there ambiguities?
- Add disambiguation to the pom.xml
- Go to step 1.
3. Record the final dependency graph:
`mvn dependency:tree -B > deps.txt`

## Examples

_NOTE:_ The version of `com.github.jnr:jffi` was chosen to be 1.2.16 specifically to line up with the native version of the package (this does not appear to work withi 1.2.17)

[ambiguities.txt](https://github.com/oceanprotocol/squid-java/files/3081860/ambiguities.txt)
[deps.txt](https://github.com/oceanprotocol/squid-java/files/3081861/deps.txt)
